### PR TITLE
Fix uploaded files always using wrong file name of "file"

### DIFF
--- a/vertx-vaadin-flow-parent/vertx-vaadin-flow/src/main/java/com/github/mcollovati/vertx/vaadin/communication/StreamReceiverHandler.java
+++ b/vertx-vaadin-flow-parent/vertx-vaadin-flow/src/main/java/com/github/mcollovati/vertx/vaadin/communication/StreamReceiverHandler.java
@@ -176,7 +176,7 @@ public class StreamReceiverHandler implements Serializable {
     private void handleStream(VaadinSession session, FileSystem fileSystem,
                               StreamReceiver streamReceiver, StateNode owner, long contentLength,
                               FileUpload item) {
-        String name = item.name();
+        String name = item.fileName();
         Buffer buffer = fileSystem.readFileBlocking(item.uploadedFileName());
         InputStream stream = new BufferInputStreamAdapter(buffer);
         try {


### PR DESCRIPTION
When using the [Vaadin upload component](https://vaadin.com/components/vaadin-upload/java-examples), uploaded files are always getting a file name of "file". This fixes the bug by using the proper variable.