### PR TITLE
test: ensure session expired notificaiton is not show (#118)

### DIFF
--- a/vertx-vaadin-tests/test-common/src/main/java/com/vaadin/flow/uitest/vertx/RouterTestServlet.java
+++ b/vertx-vaadin-tests/test-common/src/main/java/com/vaadin/flow/uitest/vertx/RouterTestServlet.java
@@ -39,6 +39,8 @@ import com.vaadin.flow.router.ParentLayout;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouteAlias;
 import com.vaadin.flow.router.RouterLayout;
+import com.vaadin.flow.server.DefaultSystemMessagesProvider;
+import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinServlet;
 import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.server.WrappedSession;
@@ -191,6 +193,8 @@ public class RouterTestServlet extends VaadinServlet {
 
         @Override
         public void beforeEnter(BeforeEnterEvent event) {
+            // Ensure session expired notification is not shown
+            VaadinService.getCurrent().setSystemMessagesProvider(DefaultSystemMessagesProvider.get());
             Location location = event.getUI().getInternals().getActiveViewLocation();
             if (!location.getPath().isEmpty()) {
                 VaadinSession.getCurrent().getSession().invalidate();

--- a/vertx-vaadin-tests/test-common/src/main/java/com/vaadin/flow/uitest/vertx/RouterTestServlet.java
+++ b/vertx-vaadin-tests/test-common/src/main/java/com/vaadin/flow/uitest/vertx/RouterTestServlet.java
@@ -159,6 +159,8 @@ public class RouterTestServlet extends VaadinServlet {
     public abstract static class MyAbstractView extends Div {
 
         protected MyAbstractView() {
+            // Ensure session expired notification is not shown
+            VaadinService.getCurrent().setSystemMessagesProvider(DefaultSystemMessagesProvider.get());
             getViewClasses().forEach(c -> {
                 String viewName = c.getSimpleName();
                 Element div = ElementFactory.createDiv();
@@ -193,8 +195,6 @@ public class RouterTestServlet extends VaadinServlet {
 
         @Override
         public void beforeEnter(BeforeEnterEvent event) {
-            // Ensure session expired notification is not shown
-            VaadinService.getCurrent().setSystemMessagesProvider(DefaultSystemMessagesProvider.get());
             Location location = event.getUI().getInternals().getActiveViewLocation();
             if (!location.getPath().isEmpty()) {
                 VaadinSession.getCurrent().getSession().invalidate();

--- a/vertx-vaadin-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/InternalErrorIT.java
+++ b/vertx-vaadin-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/InternalErrorIT.java
@@ -23,6 +23,8 @@
 package com.vaadin.flow.uitest.ui;
 
 import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+import net.jcip.annotations.NotThreadSafe;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
@@ -42,6 +44,7 @@ import static org.junit.Assert.assertTrue;
  * @author Vaadin Ltd
  * @since 1.0.
  */
+@NotThreadSafe
 public class InternalErrorIT extends ChromeBrowserTest {
 
     private static final String UPDATE = "update";

--- a/vertx-vaadin-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/RouterSessionExpirationIT.java
+++ b/vertx-vaadin-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/RouterSessionExpirationIT.java
@@ -23,11 +23,14 @@
 package com.vaadin.flow.uitest.ui;
 
 import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+import net.jcip.annotations.NotThreadSafe;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.openqa.selenium.By;
 
+@NotThreadSafe
 public class RouterSessionExpirationIT extends ChromeBrowserTest {
 
     @Override
@@ -49,7 +52,6 @@ public class RouterSessionExpirationIT extends ChromeBrowserTest {
         // be a new session
         String currentSessionId = sessionId;
         waitUntil(d -> !currentSessionId.equals(getSessionId()));
-        //Assert.assertNotEquals(sessionId, getSessionId());
         sessionId = getSessionId();
         navigateToAnotherView();
         // session is preserved


### PR DESCRIPTION
RouterSessionExpirationIT expects the page to be reloaded on session expiration, but custom messages configuration may have been modified by InternalErrorIT.